### PR TITLE
Fix typo in English error message.

### DIFF
--- a/www/shared/i18n/en.i18n.json
+++ b/www/shared/i18n/en.i18n.json
@@ -21,7 +21,7 @@
   "The_name_provided_must_be_a_string": "The name provided must be a string.",
   "The_server_s_is_running_an_out_of_date_version_Please_ask_your_server_admin_to_update_to_a_new_version_of_RocketChat": "The server %s is running an out of date version. Please ask your server admin to update to a new version of Rocket.Chat.",
   "The_server_s_is_running_an_out_of_date_version_or_doesnt_support_mobile_applications_Please_ask_your_server_admin_to_update_to_a_new_version_of_RocketChat": "The server %s is running an out of date version or doesn't support mobile applications. Please ask your server admin to update to a new version of Rocket.Chat.",
-  "The_server_s_is_not_enable_or_mobile_apps": "The server %s is not enable or mobile apps.",
+  "The_server_s_is_not_enable_or_mobile_apps": "The server %s is not enabled for mobile apps.",
   "The_URL_configured_in_your_server_s_is_not_the_same_that_you_are_using_here": "The URL configured in your server (%s) is not the same that you are using here",
   "There_is_a_new_version_available_do_you_want_to_update_now_question": "There is a new version available, do you want to update now?",
   "Update": "Update",


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->

@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR -->

Corrects what appears to be a typo in the error string when attempting to connect to a server that was not compiled with mobile apps support.
