### PR TITLE
Initial support for Sandstorm servers added

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -92,6 +92,7 @@
     <preference name="deployment-target" value="8.0" />
     <preference name="AndroidLaunchMode" value="singleTask" />
     <preference name="Orientation" value="all" />
+    <preference name="AppendUserAgent" value="git/" /><!-- 'git' is a whitelisted user agent for Sandstorm -->
     <hook src="hooks/beforePrepare.js" type="before_prepare" />
     <engine name="ios" spec="4.1.0" />
     <engine name="android" spec="5.1.1" />

--- a/config.xml
+++ b/config.xml
@@ -92,7 +92,6 @@
     <preference name="deployment-target" value="8.0" />
     <preference name="AndroidLaunchMode" value="singleTask" />
     <preference name="Orientation" value="all" />
-    <preference name="AppendUserAgent" value="git/" /><!-- 'git' is a whitelisted user agent for Sandstorm -->
     <hook src="hooks/beforePrepare.js" type="before_prepare" />
     <engine name="ios" spec="4.1.0" />
     <engine name="android" spec="5.1.1" />

--- a/www/coffee/index.coffee
+++ b/www/coffee/index.coffee
@@ -24,7 +24,14 @@ window.updateQuickActions = ->
 
 
 window.registerServer = (serverAddress) ->
-	serverAddress ?= $('#serverAddress').val().trim().toLowerCase()
+	serverAddress ?= $('#serverAddress').val().trim()
+
+	# handle Sandstorm webkeys
+	hashIndex = serverAddress.lastIndexOf '#'
+	if hashIndex != -1
+		baseUrl = serverAddress.slice 0, hashIndex
+		auth = serverAddress.slice hashIndex + 1
+		serverAddress = baseUrl.replace("http://", "http://sandstorm:#{auth}@").replace("https://", "https://sandstorm:#{auth}@")
 
 	if serverAddress.length is 0
 		serverAddress = 'https://demo.rocket.chat'

--- a/www/coffee/servers.coffee
+++ b/www/coffee/servers.coffee
@@ -337,14 +337,14 @@ window.Servers = new class
 
 			if urlObj.auth
 				schemalessUrl = baseUrl.replace('http://', '').replace('https://', '')
-				file = file.replace(/(__meteor_runtime_config__ = JSON.+$)/gm, """
-					$1
+				file = file.replace(/(^\s*__meteor_runtime_config__ = JSON.+$)/gm, """
+					/* sandstorm workaround */ $1
 				__meteor_runtime_config__.ROOT_URL = '#{baseUrl}';
 				__meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL = '#{baseUrl}';
 				__meteor_runtime_config__.SANDSTORM_API_TOKEN = '#{urlObj.auth}';
 				__meteor_runtime_config__.SANDSTORM_API_HOST = '#{baseUrl}';
 
-				window._OriginalWebSocket = window.WebSocket;
+				window._OriginalWebSocket = window._OriginalWebSocket || window.WebSocket;
 				window.WebSocket = function SandstormWebSocket (url, protocols) {
 					url = url.replace('#{schemalessUrl}',
 					"#{schemalessUrl}/.sandstorm-token/#{urlObj.auth}");


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->

@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR -->

This adds basic support for Rocket.Chat on Sandstorm. It is blocking on https://github.com/RocketChat/Rocket.Chat/pull/3437, and to test you will need to use an updated spk (available at https://oasis.sandstorm.io/shared/6ZAPj5yiY1SXs9p8VSLTYQ904IjjBptM9-a5X2MMXS9).

There's still some outstanding issues:
1. Images don't work
2. On loading the app a 2nd time, it crashes (I'm not sure this is due to anything I did since it seems to happen deep in Cordova code).
