### PR TITLE
Add intent/app links 

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -138,4 +138,7 @@
         <variable name="REVERSED_CLIENT_ID" value="com.googleusercontent.apps.673693445664-pa3k48sg81r89rn65e9rlnu4gpmm5vem" />
     </plugin>
     <plugin name="cordova-custom-config" spec="~2.0.3" />
+    <plugin name="cordova-plugin-customurlscheme" spec="~4.2.0">
+      <variable name="URL_SCHEME" value="clientapp-rocketchat" />
+    </plugin>
 </widget>

--- a/www/coffee/servers.coffee
+++ b/www/coffee/servers.coffee
@@ -363,6 +363,17 @@ window.Servers = new class
 						return new _OriginalWebSocket(url);
 					}
 				};
+
+				XMLHttpRequest._originalOpen = XMLHttpRequest._originalOpen || XMLHttpRequest.prototype.open;
+				XMLHttpRequest.prototype.open = function () {
+				  var res = XMLHttpRequest._originalOpen.apply(this, arguments);
+					if (arguments[1].indexOf("#{baseUrl}") === 0 && arguments[1].indexOf("#{baseUrl}/.sandstorm-login") !== 0) {
+						// Only send sandstorm auth for urls in the base url.
+						// Confusingly, /.sandstorm-login already sets the auth header, so skip that route.
+						this.setRequestHeader("Authorization", "Bearer #{urlObj.auth}");
+					}
+					return res;
+				}
 				""")
 			file = file.replace /(<\/head>)/gm, """
 				<link rel="stylesheet" href="/shared/css/servers-list.css"/>

--- a/www/index.html
+++ b/www/index.html
@@ -68,6 +68,17 @@
 
         <script type="text/javascript">
             FastClick.attach(document.body);
+            function handleOpenURL(url) {
+              if (url.indexOf('clientapp-rocketchat:') !== 0) {
+                return;
+              }
+              window.AUTOLOAD = false;
+              url = url.replace("%23", "#"); // iOS escapes the # character. Unescape it.
+              url = url.slice('clientapp-rocketchat:'.length);
+              Servers.onLoad(function () {
+                registerServer(url);
+              });
+            }
         </script>
     </body>
 </html>


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->

@RocketChat/core 

This adds supports for offering users a link that when clicked will open the Rocket.Chat mobile app and add the appropriate server. This is especially useful under Sandstorm, where the link is long/complicated. It uses `cordova-plugin-customurlscheme` to do the bulk of the work, and only requires a small amount of custom javascript code defined in a global `handleOpenURL` function.

This is also fixes a bug with xhrs under Sandstorm (it's now monkey-patched similarly to how WebSockets were).

@engelgabriel Can I get your opinion on using `clientapp-rocketchat` as the scheme? Beginning the scheme with `clientapp-` is required under Sandstorm, since this will be a user controlled field and we wanted to block potentially malicuous schemes such as `script`
