### PR TITLE
Remove trailing slash of server URL.

### DIFF
--- a/www/coffee/index.coffee
+++ b/www/coffee/index.coffee
@@ -33,6 +33,9 @@ window.registerServer = (serverAddress) ->
 		auth = serverAddress.slice hashIndex + 1
 		serverAddress = baseUrl.replace("http://", "http://sandstorm:#{auth}@").replace("https://", "https://sandstorm:#{auth}@")
 
+	# Remove trailing slash, if present.
+	serverAddress = serverAddress.replace(/\/$/, '')
+
 	if serverAddress.length is 0
 		serverAddress = 'https://demo.rocket.chat'
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

Currently, if the user enters a server address with a trailing slash such as "https://demo.rocket.chat/", then the app fails with a parse error: "Unexpected token <". This is because the app ends up requesting `//__cordova/manifest.json`, which the server does not find, due to the double slash.

The problem occurred to be when I was copy/pasting a server URL from gmail. Apparently gmail automatically inserts a slash on links, so `https://demo.rocket.chat` automatically becomes `https://demo.rocket.chat/`.

The problem is particularly annoying for Sandstorm, where the server URL is long and therefore likely to be copy/pasted.

This pull request fixes the problem by removing the trailing slash if it is present.

