### PR TITLE
Fix autoupdate download

### DIFF
--- a/www/coffee/servers.coffee
+++ b/www/coffee/servers.coffee
@@ -214,7 +214,7 @@ window.Servers = new class
 
 		@getManifest url, (err, info) =>
 			if err
-				return cb err
+				return cb {err:err}
 
 			if servers[url].info.version isnt info.version
 				oldInfo = servers[url].oldInfo

--- a/www/coffee/servers.coffee
+++ b/www/coffee/servers.coffee
@@ -226,7 +226,8 @@ window.Servers = new class
 						servers[url].info = servers[url].oldInfo
 						servers[url].oldInfo = oldInfo
 					cb(status)
-
+			else 
+				return cb {done: true}
 
 	getFileTransfer: ->
 		@fileTransfer ?= new FileTransfer()

--- a/www/coffee/servers.coffee
+++ b/www/coffee/servers.coffee
@@ -325,7 +325,9 @@ window.Servers = new class
 						if filesToCopy is copiedFiles
 							initDownloadServer()
 
-		if filesToCopy is 0
+			if filesToCopy is 0
+				initDownloadServer()
+		else
 			initDownloadServer()
 
 	fixIndexFile: (indexDir, baseUrl, cb) ->


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #181 

<!-- INSTRUCTION: Tell us more about your PR -->
The primary fix is related to https://github.com/RocketChat/Rocket.Chat.Cordova/commit/75d0b2940bfbc1334fc50e153578ffca1c6b06ba. The change made in that commit inadvertently caused the initDownloadServer function to be called twice at the same time on updates.

While tracking down the issue there were also 2 callback issues that would cause similar problems. The first, the update callback expects an object and was getting a string. This would cause the app to stop on the file download and report "undefined/undefined". The second, if the update is triggered but the manifest version matches when the file is actually downloaded the update callback was never called.