### PR TITLE
Fix crosswalk webview version not fit the xwalk version

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -139,7 +139,7 @@
         <variable name="PHOTOLIBRARY_USAGE_DESCRIPTION" value="Upload photos from library" />
     </plugin>
     <plugin name="cordova-plugin-console" spec="1.0.5" />
-    <plugin name="cordova-plugin-crosswalk-webview" spec="2.1.0" />
+    <plugin name="cordova-plugin-crosswalk-webview" spec="2.3.0" />
     <plugin name="cordova-plugin-device" spec="1.1.4" />
     <plugin name="cordova-plugin-dialogs" spec="1.3.1" />
     <plugin name="cordova-plugin-file" spec="4.3.1" />


### PR DESCRIPTION
@RocketChat/core 

First found this problem on upload file (Android), touch the upload button, and nothing happen.
Check the [cordova-plugin-crosswalk-webview](https://github.com/crosswalk-project/cordova-plugin-crosswalk-webview) README.md and change the crosswalk webview version, and it work fine.
